### PR TITLE
Adding init options to datastore constructor (external session factory + custom record models)

### DIFF
--- a/eventsourcing_sqlalchemy/recorders.py
+++ b/eventsourcing_sqlalchemy/recorders.py
@@ -13,11 +13,6 @@ from sqlalchemy import Column, Table
 from sqlalchemy.orm import Session
 
 from eventsourcing_sqlalchemy.datastore import SQLAlchemyDatastore
-from eventsourcing_sqlalchemy.models import (
-    NotificationTrackingRecord,
-    SnapshotRecord,
-    StoredEventRecord,
-)
 
 
 class SQLAlchemyAggregateRecorder(AggregateRecorder):
@@ -34,9 +29,9 @@ class SQLAlchemyAggregateRecorder(AggregateRecorder):
             [s.capitalize() for s in events_table_name.rstrip("s").split("_")]
         )
         if for_snapshots:
-            base_cls = SnapshotRecord
+            base_cls = self.datastore.snapshot_record_cls
         else:
-            base_cls = StoredEventRecord
+            base_cls = self.datastore.stored_event_record_cls
         self.events_record_cls = self.datastore.define_record_class(
             name=record_cls_name, table_name=self.events_table_name, base_cls=base_cls
         )
@@ -147,7 +142,7 @@ class SQLAlchemyProcessRecorder(SQLAlchemyApplicationRecorder, ProcessRecorder):
         self.tracking_record_cls = self.datastore.define_record_class(
             name="NotificationTrackingRecord",
             table_name=self.tracking_table_name,
-            base_cls=NotificationTrackingRecord,
+            base_cls=datastore.notification_tracking_record_cls,
         )
         self.tracking_table: Table = self.tracking_record_cls.__table__
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+
+from sqlalchemy.future import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from eventsourcing_sqlalchemy.datastore import SQLAlchemyDatastore
+
+
+class TestDatastore(TestCase):
+    def test_should_be_created_with_url(self):
+        datastore = SQLAlchemyDatastore(url="sqlite:///:memory:")
+        self.assertIsInstance(datastore, SQLAlchemyDatastore)
+
+    def test_should_be_created_with_session_cls(self):
+        session_cls = sessionmaker(bind=create_engine(url="sqlite:///:memory:"))
+        datastore = SQLAlchemyDatastore(session_cls=session_cls)
+        self.assertIsInstance(datastore, SQLAlchemyDatastore)
+
+    def test_should_raise_exception_without_url_or_session_cls(self):
+        with self.assertRaises(EnvironmentError):
+            SQLAlchemyDatastore()

--- a/tests/test_noninterleaving_notification_ids.py
+++ b/tests/test_noninterleaving_notification_ids.py
@@ -14,7 +14,7 @@ class TestNonInterleaving(NonInterleavingNotificationIDsBaseCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.datastore = SQLAlchemyDatastore(self.sqlalchemy_db_url)
+        self.datastore = SQLAlchemyDatastore(url=self.sqlalchemy_db_url)
 
     def create_recorder(self):
         recorder = SQLAlchemyApplicationRecorder(

--- a/tests/test_recorders.py
+++ b/tests/test_recorders.py
@@ -1,4 +1,6 @@
 from eventsourcing.tests.ramdisk import tmpfile_uris
+from sqlalchemy.future import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from eventsourcing_sqlalchemy.datastore import SQLAlchemyDatastore
 from eventsourcing_sqlalchemy.recorders import (
@@ -19,7 +21,7 @@ from eventsourcing.tests.processrecorder_testcase import ProcessRecorderTestCase
 
 class TestSQLAlchemyAggregateRecorder(AggregateRecorderTestCase):
     def setUp(self) -> None:
-        self.datastore = SQLAlchemyDatastore("sqlite:///:memory:")
+        self.datastore = SQLAlchemyDatastore(url="sqlite:///:memory:")
 
     def create_recorder(self):
         recorder = SQLAlchemyAggregateRecorder(
@@ -31,10 +33,24 @@ class TestSQLAlchemyAggregateRecorder(AggregateRecorderTestCase):
     def test_insert_and_select(self):
         super(TestSQLAlchemyAggregateRecorder, self).test_insert_and_select()
 
+class TestSQLAlchemyAggregateRecorderWithExternalSession(AggregateRecorderTestCase):
+    def setUp(self) -> None:
+        session_cls = sessionmaker(bind=create_engine(url="sqlite:///:memory:"))
+        self.datastore = SQLAlchemyDatastore(session_cls=session_cls)
+
+    def create_recorder(self):
+        recorder = SQLAlchemyAggregateRecorder(
+            datastore=self.datastore, events_table_name="stored_events"
+        )
+        recorder.create_table()
+        return recorder
+
+    def test_insert_and_select(self):
+        super(TestSQLAlchemyAggregateRecorderWithExternalSession, self).test_insert_and_select()
 
 class TestSQLAlchemySnapshotRecorder(AggregateRecorderTestCase):
     def setUp(self) -> None:
-        self.datastore = SQLAlchemyDatastore("sqlite:///:memory:")
+        self.datastore = SQLAlchemyDatastore(url="sqlite:///:memory:")
 
     def create_recorder(self):
         recorder = SQLAlchemyAggregateRecorder(
@@ -46,7 +62,7 @@ class TestSQLAlchemySnapshotRecorder(AggregateRecorderTestCase):
 
 class TestSQLAlchemyApplicationRecorder(ApplicationRecorderTestCase):
     def setUp(self) -> None:
-        self.datastore = SQLAlchemyDatastore("sqlite:///:memory:?cache=shared")
+        self.datastore = SQLAlchemyDatastore(url="sqlite:///:memory:?cache=shared")
 
     def create_recorder(self):
         recorder = SQLAlchemyApplicationRecorder(
@@ -76,7 +92,7 @@ class TestSQLAlchemyApplicationRecorder(ApplicationRecorderTestCase):
 
 class TestSQLAlchemyProcessRecorder(ProcessRecorderTestCase):
     def setUp(self) -> None:
-        self.datastore = SQLAlchemyDatastore("sqlite:///:memory:")
+        self.datastore = SQLAlchemyDatastore(url="sqlite:///:memory:")
 
     def create_recorder(self):
         recorder = SQLAlchemyProcessRecorder(datastore=self.datastore, events_table_name="stored_events",


### PR DESCRIPTION
Hello!,

We are testing the new version of eventsourcing library and it looks great! Thank you very much.

We are currently using version 8.x of the library with SQLAlchemy/Oracle and we are considering the migration to 9.x. Our main motivation is to be able to use sequences / autoincrement in the notification_id column because we have concurrency issues with the select/max query.

In the migration we have had to do some changes to this module. We need a custom factory with a datastore that could be able to:
- Use an external SQLAlchemy session (in our app the session is created outside the scope of eventsourcing library)
- Use custom SQLAlchemy record models (in Oracle we need to replace some column definitions)

This pull request adds these changes. We think that would make the datastore more flexible to use.

Best regards,
-Jose.