### PR TITLE
Add a order_by on index to force an (postgres) Index Scan

### DIFF
--- a/eventsourcing_sqlalchemy/recorders.py
+++ b/eventsourcing_sqlalchemy/recorders.py
@@ -174,6 +174,7 @@ class SQLAlchemyApplicationRecorder(SQLAlchemyAggregateRecorder, ApplicationReco
                 q = q.filter(record_class.id <= stop)
             if topics:
                 q = q.filter(record_class.topic.in_(topics))
+            q = q.order_by(record_class.id)  # Make it an index scan
             q = q[0:limit]
 
             notifications = [


### PR DESCRIPTION
As described on Slack: https://eventsourcinginpython.slack.com/archives/C627DFVJM/p1726670022073569 

By using an `order_by id` (pkey) in the sql(alchemy) query, postgres will move to always use an Index Scan instead of sometimes a Sequence Scan. 

- This keeps query behaviour the same whether you ask for events `>= 50` (sometimes/always a Sequence Scan) or events `>= 50 and <= 100` (always an Index Scan). And you always add a `LIMIT` to the first option anyway, so its not like you want to query the whole table in 1 go.
- It doesn't actually do an order, it just changes to using the already indexed primary key.
- Theoretically an Index Scan should actually perform better on large (event) tables where we want only a small (`LIMIT X`) nr of events, like in your library.
- Most importantly for me: it solves my eventsourcing issue with multiple subprocess writers (applications) that do keep the `id` (pkey) consistent, but not the actual event table row ordering. So the Sequence Scan gives me a wrong event order at some point, while the Index Scan gives me the correct event order. 

Regards, Torec